### PR TITLE
Bump action versions (checkout v6, setup-dotnet v5, upload-artifact v7)

### DIFF
--- a/.github/workflows/nuget-packages.yml
+++ b/.github/workflows/nuget-packages.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -110,7 +110,7 @@ jobs:
         fi
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -131,7 +131,7 @@ jobs:
         done
 
     - name: Upload test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: test-results
@@ -147,10 +147,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -211,13 +211,13 @@ jobs:
         ls -la ./packages/
 
     - name: Upload packages as artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nuget-packages
         path: ./packages/*.nupkg
 
     - name: Upload symbol packages as artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nuget-symbol-packages
         path: ./packages/*.snupkg

--- a/src/affolterNET.Data.DbUp/affolterNET.Data.DbUp.csproj
+++ b/src/affolterNET.Data.DbUp/affolterNET.Data.DbUp.csproj
@@ -10,7 +10,7 @@
         <PackageTags>SQL, DB, Dapper, Command, Query, ORM</PackageTags>
         <RepositoryUrl>https://github.com/affolterNET/affolterNET.Data</RepositoryUrl>
         <ProjectGuid>9845AC6B-E6C3-40F2-8FA5-50A3DBD81544</ProjectGuid>
-        <Version>3.1.2</Version>
+        <Version>3.1.3</Version>
         <IsPackable>true</IsPackable>
         <Authors>Martin Affolter</Authors>
         <Company>affolter.NET GmbH</Company>

--- a/src/affolterNET.Data.DtoHelper/affolterNET.Data.DtoHelper.csproj
+++ b/src/affolterNET.Data.DtoHelper/affolterNET.Data.DtoHelper.csproj
@@ -10,7 +10,7 @@
     <PackageTags>SQL, DB, Generate, Dto, Code, C#</PackageTags>
     <RepositoryUrl>https://github.com/affolterNET/affolterNET.Data</RepositoryUrl>
     <ProjectGuid>024E3895-4BC1-4A57-938A-009FFF961644</ProjectGuid>
-    <Version>3.1.2</Version>
+    <Version>3.1.3</Version>
     <IsPackable>true</IsPackable>
     <Authors>Martin Affolter</Authors>
     <Company>affolter.NET GmbH</Company>

--- a/src/affolterNET.Data.TestHelpers/affolterNET.Data.TestHelpers.csproj
+++ b/src/affolterNET.Data.TestHelpers/affolterNET.Data.TestHelpers.csproj
@@ -10,7 +10,7 @@
     <PackageTags>SQL, DB, Unit, Testing</PackageTags>
     <RepositoryUrl>https://github.com/affolterNET/affolterNET.Data</RepositoryUrl>
     <ProjectGuid>BB3D9D5C-5917-436B-B3AC-4A20CAF0FD67</ProjectGuid>
-    <Version>3.1.2</Version>
+    <Version>3.1.3</Version>
     <IsPackable>true</IsPackable>
     <Authors>Martin Affolter</Authors>
     <Company>affolter.NET GmbH</Company>

--- a/src/affolterNET.Data/affolterNET.Data.csproj
+++ b/src/affolterNET.Data/affolterNET.Data.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/affolterNET/affolterNET.Data</RepositoryUrl>
     <ProjectGuid>7F8BACB2-B376-4713-B2FC-8C3C0F089D9C</ProjectGuid>
     <UserSecretsId>eeff2dd1-fe6c-40f0-a5c6-e551d9b1b813</UserSecretsId>
-    <Version>3.1.2</Version>
+    <Version>3.1.3</Version>
     <IsPackable>true</IsPackable>
     <Authors>Martin Affolter</Authors>
     <Company>affolter.NET GmbH</Company>


### PR DESCRIPTION
## Summary
- Bump GitHub Action versions in nuget-packages.yml: `actions/checkout@v4→v6`, `actions/setup-dotnet@v4→v5`, `actions/upload-artifact@v4→v7`. All 3 upload sites use multi-file glob paths, so v7's no-zip single-file behavior does not affect them.

## Test plan
- [x] CI green on develop (run 25103024633)
- [ ] On merge to main: NuGet packages publish to nuget.org with the patch-bumped version